### PR TITLE
(wip) Add useAnimatedWindow

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -668,4 +668,32 @@ void NativeReanimatedModule::unsubscribeFromKeyboardEvents(
   unsubscribeFromKeyboardEventsFunction_(listenerId.asNumber());
 }
 
+jsi::Value NativeReanimatedModule::subscribeForWindowEvents(
+    jsi::Runtime &rt,
+    const jsi::Value &handlerWorklet,
+    const jsi::Value &isStatusBarTranslucent) {
+  auto shareableHandler = extractShareableOrThrow<ShareableWorklet>(
+      rt,
+      handlerWorklet,
+      "[Reanimated] Window event handler must be a worklet.");
+  return subscribeForWindowEventsFunction_(
+      [=](int width, int height, int top, int bottom, int left, int right) {
+        uiWorkletRuntime_->runGuarded(
+            shareableHandler,
+            jsi::Value(width),
+            jsi::Value(height),
+            jsi::Value(top),
+            jsi::Value(bottom),
+            jsi::Value(left),
+            jsi::Value(right));
+      },
+      isStatusBarTranslucent.getBool());
+}
+
+void NativeReanimatedModule::unsubscribeFromWindowEvents(
+    jsi::Runtime &,
+    const jsi::Value &listenerId) {
+  unsubscribeFromWindowEventsFunction_(listenerId.asNumber());
+}
+
 } // namespace reanimated

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -151,6 +151,13 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       jsi::Runtime &rt,
       const jsi::Value &listenerId) override;
 
+  jsi::Value subscribeForWindowEvents(
+      jsi::Runtime &rt,
+      const jsi::Value &keyboardEventContainer) override;
+  void unsubscribeFromWindowEvents(
+      jsi::Runtime &rt,
+      const jsi::Value &listenerId) override;
+
   inline LayoutAnimationsManager &layoutAnimationsManager() {
     return layoutAnimationsManager_;
   }
@@ -209,6 +216,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;
+
+  const WindowEventSubscribeFunction subscribeForWindowEventsFunction_;
+  const WindowEventUnsubscribeFunction unsubscribeFromWindowEventsFunction_;
 
 #ifdef DEBUG
   SingleInstanceChecker<NativeReanimatedModule> singleInstanceChecker_;

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -162,6 +162,25 @@ static jsi::Value SPEC_PREFIX(unsubscribeFromKeyboardEvents)(
   return jsi::Value::undefined();
 }
 
+static jsi::Value SPEC_PREFIX(subscribeForWindowEvents)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->subscribeForWindowEvents(rt, std::move(args[0]), std::move(args[1]));
+}
+
+static jsi::Value SPEC_PREFIX(unsubscribeFromWindowEvents)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->unsubscribeFromWindowEvents(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
 static jsi::Value SPEC_PREFIX(configureLayoutAnimation)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -220,6 +239,10 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
       MethodMetadata{2, SPEC_PREFIX(subscribeForKeyboardEvents)};
   methodMap_["unsubscribeFromKeyboardEvents"] =
       MethodMetadata{1, SPEC_PREFIX(unsubscribeFromKeyboardEvents)};
+  methodMap_["subscribeForWindowEvents"] =
+      MethodMetadata{2, SPEC_PREFIX(subscribeForWindowEvents)};
+  methodMap_["unsubscribeFromWindowEvents"] =
+      MethodMetadata{1, SPEC_PREFIX(unsubscribeFromWindowEvents)};
 
   methodMap_["configureLayoutAnimation"] =
       MethodMetadata{4, SPEC_PREFIX(configureLayoutAnimation)};

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
@@ -86,6 +86,15 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &listenerId) = 0;
 
+  // window
+  virtual jsi::Value subscribeForWindowEvents(
+      jsi::Runtime &rt,
+      const jsi::Value &windowEventContainer,
+      const jsi::Value &isStatusBarTranslucent) = 0;
+  virtual void unsubscribeFromWindowEvents(
+      jsi::Runtime &rt,
+      const jsi::Value &listenerId) = 0;
+
   // other
   virtual jsi::Value enableLayoutAnimations(
       jsi::Runtime &rt,

--- a/Common/cpp/Tools/PlatformDepMethodsHolder.h
+++ b/Common/cpp/Tools/PlatformDepMethodsHolder.h
@@ -70,6 +70,9 @@ using ConfigurePropsFunction = std::function<void(
 using KeyboardEventSubscribeFunction =
     std::function<int(std::function<void(int, int)>, bool)>;
 using KeyboardEventUnsubscribeFunction = std::function<void(int)>;
+using WindowEventSubscribeFunction =
+    std::function<int(std::function<void(int, int, int, int, int, int)>, bool)>;
+using WindowEventUnsubscribeFunction = std::function<void(int)>;
 using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 
 struct PlatformDepMethodsHolder {
@@ -92,6 +95,8 @@ struct PlatformDepMethodsHolder {
   SetGestureStateFunction setGestureStateFunction;
   KeyboardEventSubscribeFunction subscribeForKeyboardEvents;
   KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEvents;
+  WindowEventSubscribeFunction subscribeForWindowEvents;
+  WindowEventUnsubscribeFunction unsubscribeFromWindowEvents;
   MaybeFlushUIUpdatesQueueFunction maybeFlushUIUpdatesQueueFunction;
 };
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -369,6 +369,26 @@ void NativeProxy::unsubscribeFromKeyboardEvents(int listenerId) {
   method(javaPart_.get(), listenerId);
 }
 
+int NativeProxy::subscribeForWindowEvents(
+    std::function<void(int, int, int, int, int, int)> windowEventDataUpdater,
+    bool isStatusBarTranslucent) {
+  static const auto method =
+      getJniMethod<int(WindowEventDataUpdater::javaobject, bool)>(
+          "subscribeForWindowEvents");
+  return method(
+      javaPart_.get(),
+      WindowEventDataUpdater::newObjectCxxArgs(
+          std::move(WindowEventDataUpdater))
+          .get(),
+      isStatusBarTranslucent);
+}
+
+void NativeProxy::unsubscribeFromWindowEvents(int listenerId) {
+  static const auto method =
+      getJniMethod<void(int)>("unsubscribeFromWindowEvents");
+  method(javaPart_.get(), listenerId);
+}
+
 double NativeProxy::getCurrentTime() {
   static const auto method = getJniMethod<jlong()>("getCurrentTime");
   jlong output = method(javaPart_.get());
@@ -466,6 +486,12 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   auto unsubscribeFromKeyboardEventsFunction =
       bindThis(&NativeProxy::unsubscribeFromKeyboardEvents);
 
+  auto subscribeForWindowEventsFunction =
+      bindThis(&NativeProxy::subscribeForWindowEvents);
+
+  auto unsubscribeFromWindowEventsFunction =
+      bindThis(&NativeProxy::unsubscribeFromWindowEvents);
+
   auto progressLayoutAnimation =
       bindThis(&NativeProxy::progressLayoutAnimation);
 
@@ -496,6 +522,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
       setGestureStateFunction,
       subscribeForKeyboardEventsFunction,
       unsubscribeFromKeyboardEventsFunction,
+      subscribeForWindowEventsFunction,
+      unsubscribeFromWindowEventsFunction,
       maybeFlushUiUpdatesQueueFunction,
   };
 }

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -142,6 +142,39 @@ class KeyboardEventDataUpdater : public HybridClass<KeyboardEventDataUpdater> {
   std::function<void(int, int)> callback_;
 };
 
+class WindowEventDataUpdater : public HybridClass<WindowEventDataUpdater> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/swmansion/reanimated/nativeProxy/WindowEventDataUpdater;";
+
+  void windowEventDataUpdater(
+      int width,
+      int height,
+      int top,
+      int bottom,
+      int left,
+      int right) {
+    callback_(width, height, top, bottom, left, right);
+  }
+
+  static void registerNatives() {
+    javaClassStatic()->registerNatives({
+        makeNativeMethod(
+            "windowEventDataUpdater",
+            WindowEventDataUpdater::windowEventDataUpdater),
+    });
+  }
+
+ private:
+  friend HybridBase;
+
+  explicit WindowEventDataUpdater(
+      std::function<void(int, int, int, int, int, int)> callback)
+      : callback_(std::move(callback)) {}
+
+  std::function<void(int, int, int, int, int, int)> callback_;
+};
+
 class NativeProxy : public jni::HybridClass<NativeProxy> {
  public:
   static auto constexpr kJavaDescriptor =
@@ -209,6 +242,10 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       std::function<void(int, int)> keyboardEventDataUpdater,
       bool isStatusBarTranslucent);
   void unsubscribeFromKeyboardEvents(int listenerId);
+  int subscribeForWindowEvents(
+      std::function<void(int, int, int, int, int, int)> windowEventDataUpdater,
+      bool isStatusBarTranslucent);
+  void unsubscribeFromWindowEvents(int listenerId);
 #ifdef RCT_NEW_ARCH_ENABLED
   // nothing
 #else

--- a/android/src/main/cpp/OnLoad.cpp
+++ b/android/src/main/cpp/OnLoad.cpp
@@ -14,5 +14,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     reanimated::LayoutAnimations::registerNatives();
     reanimated::SensorSetter::registerNatives();
     reanimated::KeyboardEventDataUpdater::registerNatives();
+    reanimated::WindowEventDataUpdater::registerNatives();
   });
 }

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -22,6 +22,7 @@ import com.swmansion.reanimated.NodesManager;
 import com.swmansion.reanimated.ReanimatedModule;
 import com.swmansion.reanimated.Utils;
 import com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener;
+import com.swmansion.reanimated.windowObserver.ReanimatedWindowEventListener;
 import com.swmansion.reanimated.layoutReanimation.AnimationsManager;
 import com.swmansion.reanimated.layoutReanimation.LayoutAnimations;
 import com.swmansion.reanimated.sensor.ReanimatedSensorContainer;
@@ -221,6 +222,18 @@ public abstract class NativeProxyCommon {
   @DoNotStrip
   public void unsubscribeFromKeyboardEvents(int listenerId) {
     reanimatedKeyboardEventListener.unsubscribeFromKeyboardEvents(listenerId);
+  }
+
+  @DoNotStrip
+  public int subscribeForWindowEvents(
+      WindowEventDataUpdater windowEventDataUpdater, boolean isStatusBarTranslucent) {
+    return reanimatedWindowEventListener.subscribeForWindowEvents(
+        keyboardEventDataUpdater, isStatusBarTranslucent);
+  }
+
+  @DoNotStrip
+  public void unsubscribeFromWindowEvents(int listenerId) {
+    reanimatedWindowEventListener.unsubscribeFromWindowEvents(listenerId);
   }
 
   protected abstract HybridData getHybridData();

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/WindowEventDataUpdater.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/WindowEventDataUpdater.java
@@ -1,0 +1,16 @@
+package com.swmansion.reanimated.nativeProxy;
+
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStrip;
+
+@DoNotStrip
+public class WindowEventDataUpdater {
+  @DoNotStrip private final HybridData mHybridData;
+
+  @DoNotStrip
+  private WindowEventDataUpdater(HybridData hybridData) {
+    mHybridData = hybridData;
+  }
+
+  public native void WindowEventDataUpdater(int width, int height, int top, int bottom, int left, int right);
+}

--- a/android/src/main/java/com/swmansion/reanimated/windowObserver/ReanimatedWindowEventListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/windowObserver/ReanimatedWindowEventListener.java
@@ -1,0 +1,86 @@
+package com.swmansion.reanimated.WindowObserver;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsAnimationCompat;
+import androidx.core.view.WindowInsetsCompat;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.PixelUtil;
+import com.swmansion.reanimated.BuildConfig;
+import com.swmansion.reanimated.nativeProxy.WindowEventDataUpdater;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.List;
+
+public class ReanimatedWindowEventListener {
+  private final WeakReference<ReactApplicationContext> reactContext;
+  private int nextListenerId = 0;
+  private final HashMap<Integer, WindowEventDataUpdater> listeners = new HashMap<>();
+  private boolean isStatusBarTranslucent = false;
+
+  public ReanimatedWindowEventListener(WeakReference<ReactApplicationContext> reactContext) {
+    this.reactContext = reactContext;
+  }
+
+  private View getRootView() {
+    return reactContext.get().getCurrentActivity().getWindow().getDecorView();
+  }
+
+  private void updateWindow(int width, int height, int top, int bottom, int left, int right) {
+    for (WindowEventDataUpdater listener : listeners.values()) {
+      listener.WindowEventDataUpdater(width, height, top, bottom, left, right);
+    }
+  }
+
+  private class WindowInsetsCallback implements OnApplyWindowInsetsListener {
+    private int width = 0;
+    private int height = 0;
+    private int top = 0;
+    private int bottom = 0;
+    private int left = 0;
+    private int right = 0;
+
+    @NonNull
+    @Override
+    public WindowInsetsCompat onApplyWindowInsets(
+        @NonNull View v,
+        @NonNull WindowInsetsCompat insets) {
+      updateWindow(width, height, top, bottom, left, right);
+    }
+  }
+
+  private void setUpCallbacks() {
+    View rootView = getRootView();
+    ViewCompat.setOnApplyWindowInsetsListener(rootView, new WindowInsetsCallback());
+  }
+
+  public int subscribeForWindowEvents(
+      WindowEventDataUpdater updater, boolean isStatusBarTranslucent) {
+    int listenerId = nextListenerId++;
+    if (listeners.isEmpty()) {
+      this.isStatusBarTranslucent = isStatusBarTranslucent;
+      setUpCallbacks();
+    }
+    listeners.put(listenerId, updater);
+    return listenerId;
+  }
+
+
+  private void removeCallbacks() {
+    View rootView = getRootView();
+    ViewCompat.setWindowInsetsAnimationCallback(rootView, null);
+  }
+
+  public void unsubscribeFromWindowEvents(int listenerId) {
+    listeners.remove(listenerId);
+    if (listeners.isEmpty()) {
+      removeCallbacks();
+    }
+  }
+}

--- a/apple/native/NativeProxy.mm
+++ b/apple/native/NativeProxy.mm
@@ -9,6 +9,7 @@
 #import <RNReanimated/REAModule.h>
 #import <RNReanimated/REANodesManager.h>
 #import <RNReanimated/REASwizzledUIManager.h>
+#import <RNReanimated/REAWindowEventObserver.h>
 #import <RNReanimated/RNGestureHandlerStateManager.h>
 #import <RNReanimated/ReanimatedRuntime.h>
 #import <RNReanimated/ReanimatedSensorContainer.h>
@@ -264,6 +265,24 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   };
   // end keyboard events
 
+  // window events
+
+  REAWindowEventObserver *windowObserver = [[REAWindowEventObserver alloc] init];
+  auto subscribeForWindowEventsFunction =
+      [=](std::function<void(int width, int height, int top, int bottom, int left, int right)> windowEventDataUpdater,
+          bool isStatusBarTranslucent) {
+        // ignore isStatusBarTranslucent - it's Android only
+        return [windowObserver
+            subscribeForWindowEvents:^(int width, int height, int top, int bottom, int left, int right) {
+              windowEventDataUpdater(width, height, top, bottom, left right);
+            }];
+      };
+
+  auto unsubscribeFromWindowEventsFunction = [=](int listenerId) {
+    [windowObserver unsubscribeFromWindowEvents:listenerId];
+  };
+  // end window events
+
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -284,6 +303,8 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
       setGestureStateFunction,
       subscribeForKeyboardEventsFunction,
       unsubscribeFromKeyboardEventsFunction,
+      subscribeForWindowEventsFunction,
+      unsubscribeFromWindowEventsFunction,
       maybeFlushUIUpdatesQueueFunction,
   };
 

--- a/apple/windowObserver/REAWindowEventObserver.h
+++ b/apple/windowObserver/REAWindowEventObserver.h
@@ -1,0 +1,16 @@
+#ifndef REAWindowEventManager_h
+#define REAWindowEventManager_h
+
+#import <React/RCTEventDispatcher.h>
+
+typedef void (^WindowEventListenerBlock)(int width, int height, int top, int bottom, int left, int right);
+
+@interface REAWindowEventObserver : NSObject
+
+- (instancetype)init;
+- (int)subscribeForWindowEvents:(WindowEventListenerBlock)listener;
+- (void)unsubscribeFromWindowEvents:(int)listenerId;
+
+@end
+
+#endif /* REAWindowEventManager_h */

--- a/apple/windowObserver/REAWindowEventObserver.m
+++ b/apple/windowObserver/REAWindowEventObserver.m
@@ -1,0 +1,113 @@
+#import <Foundation/Foundation.h>
+#import <RNReanimated/READisplayLink.h>
+#import <RNReanimated/REAUIKit.h>
+#import <RNReanimated/REAWindowEventObserver.h>
+#import <React/RCTDefines.h>
+#import <React/RCTUIManager.h>
+
+@implementation REAWindowEventObserver {
+  NSNumber *_nextListenerId;
+  NSMutableDictionary *_listeners;
+  READisplayLink *_displayLink;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  _listeners = [[NSMutableDictionary alloc] init];
+  _nextListenerId = @0;
+  _state = UNKNOWN;
+
+  NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+
+  [notificationCenter addObserver:self
+                         selector:@selector(cleanupListeners)
+                             name:RCTBridgeDidInvalidateModulesNotification
+                           object:nil];
+  return self;
+}
+
+- (READisplayLink *)getDisplayLink
+{
+  RCTAssertMainQueue();
+
+  if (!_displayLink) {
+    _displayLink = [READisplayLink displayLinkWithTarget:self selector:@selector(updateKeyboardFrame)];
+#if !TARGET_OS_OSX
+    _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+#endif
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+  }
+  return _displayLink;
+}
+
+#if TARGET_OS_TV
+- (int)subscribeForWindowEvents:(WindowEventListenerBlock)listener
+{
+  NSLog(@"Window handling is not supported on tvOS");
+  return 0;
+}
+
+- (void)unsubscribeFromWindowEvents:(int)listenerId
+{
+  NSLog(@"Window handling is not supported on tvOS");
+}
+
+#elif TARGET_OS_OSX
+
+- (int)subscribeForWindowEvents:(WindowEventListenerBlock)listener
+{
+  NSLog(@"Window handling is not supported on macOS");
+  return 0;
+}
+
+- (void)unsubscribeFromWindowEvents:(int)listenerId
+{
+  NSLog(@"Window handling is not supported on macOS");
+}
+
+#else
+
+- (int)subscribeForWindowEvents:(WindowEventListenerBlock)listener
+{
+  NSNumber *listenerId = [_nextListenerId copy];
+  _nextListenerId = [NSNumber numberWithInt:[_nextListenerId intValue] + 1];
+  RCTExecuteOnMainQueue(^() {
+    if ([self->_listeners count] == 0) {
+      NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+
+      [notificationCenter addObserver:self
+                             selector:@selector(keyboardWillChangeFrame:)
+                                 name:UIKeyboardWillChangeFrameNotification
+                               object:nil];
+    }
+
+    [self->_listeners setObject:listener forKey:listenerId];
+  });
+  return [listenerId intValue];
+}
+
+- (void)unsubscribeFromWindowEvents:(int)listenerId
+{
+  RCTExecuteOnMainQueue(^() {
+    NSNumber *_listenerId = [NSNumber numberWithInt:listenerId];
+    [self->_listeners removeObjectForKey:_listenerId];
+    if ([self->_listeners count] == 0) {
+      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
+    }
+  });
+}
+
+- (void)cleanupListeners
+{
+  RCTUnsafeExecuteOnMainQueueSync(^() {
+    [self->_listeners removeAllObjects];
+    [[self getDisplayLink] invalidate];
+    self->_displayLink = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+  });
+}
+
+#endif
+
+@end

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -56,6 +56,11 @@ export interface NativeReanimatedModule {
     isStatusBarTranslucent: boolean
   ): number;
   unsubscribeFromKeyboardEvents(listenerId: number): void;
+  subscribeForWindowEvents(
+    handler: ShareableRef<number>,
+    isStatusBarTranslucent: boolean
+  ): number;
+  unsubscribeFromWindowEvents(listenerId: number): void;
   configureLayoutAnimation(
     viewTag: number,
     type: LayoutAnimationType,
@@ -210,5 +215,19 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
 
   unsubscribeFromKeyboardEvents(listenerId: number) {
     this.InnerNativeModule.unsubscribeFromKeyboardEvents(listenerId);
+  }
+
+  subscribeForWindowEvents(
+    handler: ShareableRef<number>,
+    isStatusBarTranslucent: boolean
+  ) {
+    return this.InnerNativeModule.subscribeForWindowEvents(
+      handler,
+      isStatusBarTranslucent
+    );
+  }
+
+  unsubscribeFromWindowEvents(listenerId: number) {
+    this.InnerNativeModule.unsubscribeFromWindowEvents(listenerId);
   }
 }

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -201,6 +201,15 @@ export type AnimatedKeyboardInfo = {
   state: SharedValue<KeyboardState>;
 };
 
+export type AnimatedWindowInfo = {
+  width: SharedValue<number>;
+  height: SharedValue<number>;
+  top: SharedValue<number>;
+  bottom: SharedValue<number>;
+  left: SharedValue<number>;
+  right: SharedValue<number>;
+};
+
 export interface MeasuredDimensions {
   x: number;
   y: number;
@@ -211,6 +220,10 @@ export interface MeasuredDimensions {
 }
 
 export interface AnimatedKeyboardOptions {
+  isStatusBarTranslucentAndroid?: boolean;
+}
+
+export interface AnimatedWindowOptions {
   isStatusBarTranslucentAndroid?: boolean;
 }
 

--- a/src/reanimated2/hook/index.ts
+++ b/src/reanimated2/hook/index.ts
@@ -30,6 +30,7 @@ export { useAnimatedSensor } from './useAnimatedSensor';
 export { useFrameCallback } from './useFrameCallback';
 export type { FrameCallback } from './useFrameCallback';
 export { useAnimatedKeyboard } from './useAnimatedKeyboard';
+export { useAnimatedWindow } from './useAnimatedWindow';
 export { useScrollViewOffset } from './useScrollViewOffset';
 export type {
   EventHandler,

--- a/src/reanimated2/hook/useAnimatedWindow.ts
+++ b/src/reanimated2/hook/useAnimatedWindow.ts
@@ -1,0 +1,62 @@
+'use strict';
+import { useEffect, useRef } from 'react';
+import {
+  makeMutable,
+  subscribeForWindowEvents,
+  unsubscribeFromWindowEvents,
+} from '../core';
+import type {
+  AnimatedWindowInfo,
+  AnimatedWindowOptions,
+} from '../commonTypes';
+
+export function useAnimatedWindow(
+  options: AnimatedWindowOptions = { isStatusBarTranslucentAndroid: false }
+): AnimatedWindowInfo {
+  const ref = useRef<AnimatedWindowInfo | null>(null);
+  const listenerId = useRef<number>(-1);
+  const isSubscribed = useRef<boolean>(false);
+
+  if (ref.current === null) {
+    const WindowEventData: AnimatedWindowInfo = {
+      width: makeMutable(0),
+      height: makeMutable(0),
+      top: makeMutable(0),
+      bottom: makeMutable(0),
+      left: makeMutable(0),
+      right: makeMutable(0),
+    };
+    listenerId.current = subscribeForWindowEvents((width, height, top, bottom, left, right) => {
+      'worklet';
+      WindowEventData.width.value = width;
+      WindowEventData.height.value = height;
+      WindowEventData.top.value = top;
+      WindowEventData.bottom.value = bottom;
+      WindowEventData.left.value = left;
+      WindowEventData.right.value = right;
+    }, options);
+    ref.current = WindowEventData;
+    isSubscribed.current = true;
+  }
+  useEffect(() => {
+    if (isSubscribed.current === false && ref.current !== null) {
+      const WindowEventData = ref.current;
+      // subscribe again after Fast Refresh
+      listenerId.current = subscribeForWindowEvents((width, height, top, bottom, left, right) => {
+        'worklet';
+        WindowEventData.width.value = width;
+        WindowEventData.height.value = height;
+        WindowEventData.top.value = top;
+        WindowEventData.bottom.value = bottom;
+        WindowEventData.left.value = left;
+        WindowEventData.right.value = right;
+      }, options);
+      isSubscribed.current = true;
+    }
+    return () => {
+      unsubscribeFromWindowEvents(listenerId.current);
+      isSubscribed.current = false;
+    };
+  }, []);
+  return ref.current;
+}

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -240,6 +240,8 @@ export {
   InterfaceOrientation,
   KeyboardState,
   ReduceMotion,
+  AnimatedWindowInfo,
+  AnimatedWindowOptions,
 } from './commonTypes';
 export type { FrameInfo } from './frameCallback';
 export { getUseOfValueInStyleWarning } from './pluginUtils';

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -228,6 +228,31 @@ export default class JSReanimated {
     // noop
   }
 
+  subscribeForWindowEvents(_: ShareableRef<number>): number {
+    if (isWeb()) {
+      console.warn(
+        '[Reanimated] useAnimatedWindow is not available on web yet.'
+      );
+    } else if (isChromeDebugger()) {
+      console.warn(
+        '[Reanimated] useAnimatedWindow is not available when using Chrome Debugger.'
+      );
+    } else if (isJest()) {
+      console.warn(
+        '[Reanimated] useAnimatedWindow is not available when using Jest.'
+      );
+    } else {
+      console.warn(
+        '[Reanimated] useAnimatedWindow is not available on this configuration.'
+      );
+    }
+    return -1;
+  }
+
+  unsubscribeFromWindowEvents(_: number): void {
+    // noop
+  }
+
   initializeSensor(sensorType: SensorType, interval: number): WebSensor {
     const config =
       interval <= 0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Shared value that contains window size, insets, font scale, and orientation. More values, such as those related to Android foldables, may be added in the future.

Implementation inspired by `useAnimatedKeyboard` (https://github.com/software-mansion/react-native-reanimated/pull/3263/files).

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

### Example Usage
```ts
const {width, height, top, bottom, left, right, fontScale, orientation} = useAnimatedWindow().value;
```

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
